### PR TITLE
Update graphene 3.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
     - python
     - graphql-core >=3.1,<3.3
     - graphql-relay >=3.1,<3.3
-    - aniso8601 >=8,<10
+    - python-dateutil >=2.7.0,<3
+    - typing-extensions >=4.7.1,<5
 
 test:
   source_files:
@@ -35,10 +36,10 @@ test:
     # for tests
     - iso8601 >=1,<2
     - mock >=4,<5
-    - pytest >=6,<7
+    - pytest >=8,<9
     - pytest-asyncio >=0.16,<2
-    - pytest-benchmark >=3.4,<4
-    - pytest-cov >=3,<4
+    - pytest-benchmark >=4,<5
+    - pytest-cov >=5,<6
     - pytest-mock >=3,<4
     - pytz
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "graphene" %}
 {% set version = "3.4.3" %}
 
 package:
-  name: graphene
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/graphene/graphene-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 2a3786948ce75fe7e078443d37f609cbe5bb36ad8d6b828740ad3b95ed1a0aaa
 
 build:
@@ -36,6 +37,7 @@ test:
     # for tests
     - iso8601 >=1,<2
     - mock >=4,<5
+    # locking to lower test dependencies while we don't satisfy all pytest versions
     - pytest >=6,<8
     - pytest-asyncio >=0.16,<2
     - pytest-benchmark >=3.4,<5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3" %}
+{% set version = "3.4.3" %}
 
 package:
   name: graphene
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/graphene/graphene-{{ version }}.tar.gz
-  sha256: 529bf40c2a698954217d3713c6041d69d3f719ad0080857d7ee31327112446b0
+  sha256: 2a3786948ce75fe7e078443d37f609cbe5bb36ad8d6b828740ad3b95ed1a0aaa
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,10 +36,10 @@ test:
     # for tests
     - iso8601 >=1,<2
     - mock >=4,<5
-    - pytest >=8,<9
+    - pytest >=6,<8
     - pytest-asyncio >=0.16,<2
-    - pytest-benchmark >=4,<5
-    - pytest-cov >=5,<6
+    - pytest-benchmark >=3.4,<5
+    - pytest-cov >=3,<5
     - pytest-mock >=3,<4
     - pytz
   imports:


### PR DESCRIPTION
graphene 3.4.3

**Destination channel:** defaults

### Links

- [PKG-9941](https://anaconda.atlassian.net/browse/PKG-9941) 
- [Upstream repository](https://github.com/graphql-python/graphene)
- [Upstream changelog/diff](https://github.com/graphql-python/graphene/releases/tag/v3.4.3)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

  - Updated graphene from 3.3 to 3.4.3 for Python 3.13 support
  - Added missing required runtime dependencies:
    - python-dateutil >=2.7.0,<3
    - typing-extensions >=4.7.1,<5
  - Removed deprecated aniso8601 dependency (no longer required in 3.4.3)
  - Test Dependency Version Considerations:
    - Relaxed test dependency versions for defaults channel compatibility:
      - pytest >=6,<8 (instead of upstream's >=8,<9)
      - pytest-benchmark >=3.4,<5 (instead of upstream's >=4,<5)
      - pytest-cov >=3,<5 (instead of upstream's >=5,<6)
    - Reasoning: The exact upstream test versions (pytest >=8,<9, pytest-cov >=5,<6) are not available in the defaults channel, causing CI build failures with "unsupported request" errors
    - Alternative: To use exact upstream test versions would require adding conda-forge as a channel source during the test phase, which may impact CI configuration
    - Runtime dependencies unaffected: All critical runtime dependencies (python-dateutil, typing-extensions, graphql-core, graphql-relay) match upstream specifications exactly



[PKG-9941]: https://anaconda.atlassian.net/browse/PKG-9941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ